### PR TITLE
GHC 8.8+ migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the KU Leuven Haskell Compiler, a simple Haskell compil
 The compiler is constructed at KU Leuven, under the programming languages group of [prof Tom Schrijvers](https://people.cs.kuleuven.be/~tom.schrijvers/), to serve as a basis for implementing and testing new compiler features.
 This work is based on the following [prototype implementation](https://github.com/gkaracha/quantcs-impl).
 
-**Tested with GHC 8.4.3**
+**Tested with GHC 8.10.2**
 
 ## Implementation ##
 

--- a/Utils/Unique.hs
+++ b/Utils/Unique.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE CPP                   #-}
 
 -- ----------------------------------------------------------------------------
 -- |
@@ -67,6 +68,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Except
 import Control.Monad.Writer
+import qualified Control.Monad.Fail as Fail
 
 -- ----------------------------------------------------------------------------
 --                            Arrow TyCon Unique
@@ -268,6 +270,12 @@ instance Monad m => Monad (UniqueSupplyT m) where
   {-# INLINE return #-}
   UST m >>= f = UST (\us0 -> m us0 >>= \(x,us1) -> unUST (f x) us1)
   {-# INLINE (>>=) #-}
+#if !MIN_VERSION_base(4,11,0)
+  fail str = UST (\_ -> fail str)
+  {-# INLINE fail #-}
+#endif
+
+instance MonadFail m => MonadFail (UniqueSupplyT m) where
   fail str = UST (\_ -> fail str)
   {-# INLINE fail #-}
 


### PR DESCRIPTION
The MonadFail overhaul was completed in GHC 8.8, featuring breaking changes. See [the MonadFail proposal](https://wiki.haskell.org/MonadFail_Proposal) for details.