### PR TITLE
Updated gitignore for cabal 3.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/*
+dist-newstyle/*


### PR DESCRIPTION
Since version 3.0 cabal uses dist-newstyle instead of dist for buildoutput